### PR TITLE
Allow base hostname to be configurable

### DIFF
--- a/s3tup/connection.py
+++ b/s3tup/connection.py
@@ -32,7 +32,7 @@ log = logging.getLogger('s3tup.connection')
 class Connection(object):
 
     def __init__(self, access_key_id=None, secret_access_key=None,
-                 concurrency=5):
+                 hostname=None, concurrency=5):
         if access_key_id is None:
             try:
                 access_key_id = os.environ['AWS_ACCESS_KEY_ID']
@@ -43,9 +43,12 @@ class Connection(object):
                 secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
             except KeyError:
                 raise SecretAccessKeyNotFound()
+        if hostname is None:
+            hostname = "s3.amazonaws.com"
 
         self.access_key_id = access_key_id
         self.secret_access_key = secret_access_key
+        self.hostname = hostname
 
         self.concurrency = concurrency
         self._joined = False
@@ -116,7 +119,7 @@ class Connection(object):
                     params.pop(k)
 
         # Construct target url
-        url = 'http://{}.s3.amazonaws.com'.format(bucket)
+        url = 'http://{}.{}'.format(bucket, self.hostname)
         url += '/{}'.format(key) if key is not None else '/'
         if isinstance(params, dict) and len(params) > 0:
             url += '?{}'.format(urllib.urlencode(params))
@@ -128,7 +131,7 @@ class Connection(object):
             headers = {}
         headers = CaseInsensitiveDict(headers)
 
-        headers['Host'] = '{}.s3.amazonaws.com'.format(bucket)
+        headers['Host'] = '{}.{}'.format(bucket, self.hostname)
 
         if data is not None:
             try:

--- a/s3tup/constants.py
+++ b/s3tup/constants.py
@@ -34,6 +34,7 @@ BUCKET_ATTRS = (
     'acl',
     'canned_acl',
     'cors',
+    'hostname',
     'lifecycle',
     'logging',
     'notification',

--- a/s3tup/parse.py
+++ b/s3tup/parse.py
@@ -119,7 +119,11 @@ def parse_bucket(config):
 
     access_key_id = config.pop('access_key_id', None)
     secret_access_key = config.pop('secret_access_key', None)
-    conn = Connection(access_key_id, secret_access_key)
+    if 'hostname' in config:
+        hostname = config.pop('hostname', None)
+    else:
+        hostname = "s3.amazonaws.com"
+    conn = Connection(access_key_id, secret_access_key, hostname)
 
     with exception_ctx(bucket_name):
         if 'key_config' in config:
@@ -136,7 +140,7 @@ def parse_bucket(config):
         # Bucket will throw TypeError if it gets unknown kwargs.
         try:
             return Bucket(conn, bucket_name, key_factory, rsync_planner,
-                          **config)
+                          hostname=hostname, **config)
         except TypeError as e:
             raise convert_type_error(e)
 


### PR DESCRIPTION
Allow configurable base hostname. This can be used to connect to other S3 implementations such as the one found in Eucalyptus.
